### PR TITLE
Don't assume that make = gmake, use $(MAKE) instead.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 
 all:
-	@(cd db; $(MAKE) --no-print-directory)
-	@(cd test; $(MAKE) --no-print-directory)
+	@(cd db; $(MAKE))
+	@(cd test; $(MAKE))
 clean:
-	@(cd db; $(MAKE) clean --no-print-directory)
-	@(cd test; $(MAKE) clean --no-print-directory)
+	@(cd db; $(MAKE) clean)
+	@(cd test; $(MAKE) clean)


### PR DESCRIPTION
"make" is GNU make by default only on Linux.

Change the hardcoded "make" command to `$(MAKE)` - This make Sophia compile on non-Linux systems.
