### PR TITLE
sp_lock(): insert a pause instruction if a spinlock can't be acquired.

### DIFF
--- a/db/lock.h
+++ b/db/lock.h
@@ -9,7 +9,15 @@
  * BSD License
 */
 
+#include <unistd.h>
+
 typedef uint8_t spspinlock;
+
+#if defined(__x86_64__) || defined(__i386) || defined(_X86_)
+# define CPU_PAUSE __asm__ ("pause")
+#else
+# define CPU_PAUSE do { } while(0)
+#endif
 
 static inline void
 sp_lockinit(volatile spspinlock *l) {
@@ -23,7 +31,16 @@ sp_lockfree(volatile spspinlock *l) {
 
 static inline void
 sp_lock(volatile spspinlock *l) {
-	while (__sync_lock_test_and_set(l, 1)) {}
+	if (__sync_lock_test_and_set(l, 1) != 0) {
+		unsigned int spin_count = 0U;
+		for (;;) {
+			CPU_PAUSE;
+			if (*l == 0U && __sync_lock_test_and_set(l, 1) == 0)
+				break;
+			if (++spin_count > 100U)
+				usleep(0);
+		}
+	}
 }
 
 static inline void


### PR DESCRIPTION
Also yield to another process if acquiring the lock takes too long.
See Intel paper on efficient spinlocks.
