### PR TITLE
Don't hardcode GYP file into creating static libraries

### DIFF
--- a/sophia.gyp
+++ b/sophia.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'sophia',
       'product_prefix': 'lib',
-      'type': 'static_library',
+      'type': '<(library)',
       'include_dirs': ['db'],
       'link_settings': {
         'libraries': ['-lpthread'],


### PR DESCRIPTION
Hi there!

I wanted to build a shared library on OSX (SONAME is dylib here) and since the builtin makefile uses the .so prefix I thought I'd use GYP, but the bundled GYP file is only able to build static libraries. With this change one can build static or shared libraries depending on what the value of 'library' is set to. Here is an example of how to build a shared library on OSX, using plain makefiles as the GYP output:

```

gyp --depth=. --generator-output out -f make -Dlibrary=shared_library sophia.gyp
make -C out
```

@mmalecki: I hope this doesn't break your node binding build process :-)
