### PR TITLE
Don't define __attribute__(hot) on compilers that don't support it

### DIFF
--- a/db/macro.h
+++ b/db/macro.h
@@ -11,7 +11,11 @@
 
 #define sppacked __attribute__((packed))
 #define spunused __attribute__((unused))
-#define sphot __attribute__((hot))
+#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 3
+    #define sphot __attribute__((hot))
+#else
+    #define sphot
+#endif
 #define splikely(EXPR) __builtin_expect(!! (EXPR), 1)
 #define spunlikely(EXPR) __builtin_expect(!! (EXPR), 0)
 #define spdiv(a, b) ((a) + (b) - 1) / (b)


### PR DESCRIPTION
It's apparently a GCC-ism only supported in 4.3.0 and higher, this patch checks for it avoiding a compilation warning which happens otherwise.
