### PR TITLE
Made anonymous enum a typedef

### DIFF
--- a/db/sophia.h
+++ b/db/sophia.h
@@ -36,12 +36,12 @@ typedef enum {
 	SPVERSION  /* uint32_t*, uint32_t* */
 } spopt;
 
-enum {
+typedef enum {
 	SPO_RDONLY = 1,
 	SPO_RDWR   = 2,
 	SPO_CREAT  = 4,
 	SPO_SYNC   = 8
-};
+} spflags;
 
 typedef enum {
 	SPGT,


### PR DESCRIPTION
Hi there :-) I started writing a Python (CFFI) wrapper for Sophia [0](https://github.com/saghul/pysophia), and CFFI wouldn't manage to get SPO_CREAT and friends unless they were defined in a named typedef enum, so here is a small patch.
