### PR TITLE
Only export symbols from public API when building a shared library

### DIFF
--- a/db/makefile
+++ b/db/makefile
@@ -11,7 +11,7 @@ VERMINOR      = 1
 TARGET_STATIC = libsophia.a
 TARGET_DSOLIB = libsophia.so.$(VERMAJOR).$(VERMINOR)
 TARGET_DSO    = libsophia.so
-CFLAGS       ?= -I. -pthread -std=c99 -pedantic -Wextra -Wall -march=native -O2 -fPIC
+CFLAGS       ?= -I. -pthread -std=c99 -pedantic -Wextra -Wall -march=native -O2 -fPIC -fvisibility=hidden
 LDFLAGS      ?= -shared -soname libsophia.$(VERMAJOR)
 
 OBJS =  file.o \

--- a/db/sophia.h
+++ b/db/sophia.h
@@ -16,6 +16,13 @@ extern "C" {
 #include <stdlib.h>
 #include <stdint.h>
 
+#if __GNUC__ >= 4
+#  define SP_API __attribute__((visibility("default")))
+#else
+#  define SP_API
+#endif
+
+
 typedef void *(*spallocf)(void *ptr, size_t size, void *arg);
 typedef int (*spcmpf)(char *a, size_t asz, char *b, size_t bsz, void *arg);
 
@@ -61,24 +68,24 @@ typedef struct {
 	uint32_t indexpages;
 } spstat;
 
-void *sp_env(void);
-void *sp_open(void *env);
-int sp_ctl(void*, spopt, ...);
-int sp_destroy(void *ptr);
-int sp_begin(void *db);
-int sp_commit(void *db);
-int sp_rollback(void *db);
-int sp_set(void *db, const void *k, size_t ksize, const void *v, size_t vsize);
-int sp_delete(void *db, const void *k, size_t ksize);
-int sp_get(void *db, const void *k, size_t ksize, void **v, size_t *vsize);
-void *sp_cursor(void *db, sporder, const void *k, size_t ksize);
-int sp_fetch(void *cur);
-const char *sp_key(void *cur);
-size_t sp_keysize(void *cur);
-const char *sp_value(void *cur);
-size_t sp_valuesize(void *cur);
-char *sp_error(void *ptr);
-void sp_stat(void *ptr, spstat*);
+SP_API void *sp_env(void);
+SP_API void *sp_open(void *env);
+SP_API int sp_ctl(void*, spopt, ...);
+SP_API int sp_destroy(void *ptr);
+SP_API int sp_begin(void *db);
+SP_API int sp_commit(void *db);
+SP_API int sp_rollback(void *db);
+SP_API int sp_set(void *db, const void *k, size_t ksize, const void *v, size_t vsize);
+SP_API int sp_delete(void *db, const void *k, size_t ksize);
+SP_API int sp_get(void *db, const void *k, size_t ksize, void **v, size_t *vsize);
+SP_API void *sp_cursor(void *db, sporder, const void *k, size_t ksize);
+SP_API int sp_fetch(void *cur);
+SP_API const char *sp_key(void *cur);
+SP_API size_t sp_keysize(void *cur);
+SP_API const char *sp_value(void *cur);
+SP_API size_t sp_valuesize(void *cur);
+SP_API char *sp_error(void *ptr);
+SP_API void sp_stat(void *ptr, spstat*);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Title says all :-)
