### PR TITLE
Added conditional compilation for OSX (Darwin)

### DIFF
--- a/db/makefile
+++ b/db/makefile
@@ -2,7 +2,7 @@
 # sophia makefile.
 #
 
-CC           ?= gcc
+
 AR            = ar
 RM            = rm
 LN            = ln
@@ -10,10 +10,24 @@ STRIP         = strip
 VERMAJOR      = 1
 VERMINOR      = 1
 TARGET_STATIC = libsophia.a
-TARGET_DSOLIB = libsophia.so.$(VERMAJOR).$(VERMINOR)
-TARGET_DSO    = libsophia.so
-CFLAGS       ?= -I. -pthread -std=c99 -pedantic -Wextra -Wall -march=native -fPIC -fvisibility=hidden -O2
-LDFLAGS      ?= -shared -soname $(TARGET_DSO).$(VERMAJOR)
+
+UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Linux)    	
+        CC           ?= gcc
+        TARGET_DSOLIB = libsophia.so.$(VERMAJOR).$(VERMINOR)
+		TARGET_DSO    = libsophia.so
+		CFLAGS       ?= -I. -pthread -std=c99 -pedantic -Wextra -Wall -march=native -fPIC -fvisibility=hidden -O2
+		LDFLAGS      ?= -shared -soname $(TARGET_DSO).$(VERMAJOR)
+		STRIP_CMD 	 = $(STRIP) --strip-unneeded $(TARGET_DSO)		
+	endif
+    ifeq ($(UNAME_S),Darwin)    	
+       	CC           ?= clang
+       	TARGET_DSOLIB = libsophia.so.$(VERMAJOR).$(VERMINOR)
+		TARGET_DSO    = libsophia.so
+       	CFLAGS       ?= -I. -pthread -std=c99 -pedantic -Wextra -Wall -O2 -fPIC -march=native
+		LDFLAGS      ?= -lc -dylib 
+		STRIP_CMD	 = 
+    endif
 
 OBJS =  file.o \
 	crc.o \
@@ -37,7 +51,7 @@ $(TARGET_DSO): clean $(OBJS)
 	$(LD) $(OBJS) $(LDFLAGS) -o $(TARGET_DSOLIB)
 	$(LN) -s $(TARGET_DSOLIB) $(TARGET_DSO).$(VERMAJOR)
 	$(LN) -s $(TARGET_DSOLIB) $(TARGET_DSO)
-	$(STRIP) --strip-unneeded $(TARGET_DSO)
+	$(STRIP_CMD)
 
 .c.o:
 	$(CC) $(CFLAGS) -c $<

--- a/test/makefile
+++ b/test/makefile
@@ -1,8 +1,17 @@
 
-CC      ?= gcc
+UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Linux)    	
+        CC           ?= gcc
+        CFLAGS  ?= -I. -I../db -Wall -pthread -O0 -g
+        LDFLAGS ?= -pthread ../db/libsophia.a
+	endif
+    ifeq ($(UNAME_S),Darwin)    	
+       	CC           ?= clang
+       	CFLAGS  ?= -I. -I../db -Wall -O0 -g
+       	LDFLAGS ?= ../db/libsophia.a
+    endif
+
 RM      ?= rm
-CFLAGS  ?= -I. -I../db -Wall -pthread -O0 -g
-LDFLAGS ?= -pthread ../db/libsophia.a
 all: clean i common recover merge concurrent transaction crash limit
 common: common.o
 	$(CC) common.o $(LDFLAGS) -o common


### PR DESCRIPTION
Out of the box sophia won't compile for OS X, so I made it work and added the changes back to the Makefiles so that it will compile on both Linux and OS X. The Linux section is unchanged, flag-wise.