### PR TITLE
makefile: Add explicit targets for each built file

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@
 CC ?= cc
 
 ifdef ENABLE_COVERAGE
-CFLAGS_COVERAGE = --coverage 
+CFLAGS_COVERAGE = --coverage
 else
 CFLAGS_COVERAGE =
 endif
@@ -29,24 +29,30 @@ banner:
 	@echo "cc: $(CC)"
 	@echo "cflags: $(CFLAGS_DEBUG) $(CFLAGS_COVERAGE)$(CFLAGS_OPT) $(CFLAGS_STRICT)"
 	@echo
-sophia.o: banner clean
+sophia.c:
 	@echo build
-	@sh sophia/build sophia sophia.c
-	@echo cc sophia.c
-	@$(CC) $(SOPHIA_CFLAGS) -c sophia.c -o sophia.o
+	@sh sophia/build sophia $@
+	@echo cc $@
+sophia.h:
 	@cp sophia/sophia/sophia.h .
-static: sophia.o
+sophia.o: banner clean sophia.c sophia.h
+	@$(CC) $(SOPHIA_CFLAGS) -c sophia.c -o sophia.o
+libsophia.a: sophia.o
 	@echo "ar libsophia.a"
 	@ar crs libsophia.a sophia.o
-dynamic: sophia.o
+libsophia.so: sophia.o
 	@echo "ld libsophia.so"
 	@ld sophia.o $(SOPHIA_LDFLAGS) -o libsophia.so.1.2
 	@ln -sf libsophia.so.1.2 libsophia.so.1
 	@ln -sf libsophia.so.1.2 libsophia.so
 	@strip --strip-unneeded libsophia.so.1.2
+static: libsophia.a
+dynamic: libsophia.so
 clean:
 	@rm -f sophia.c sophia.h sophia.o
 	@rm -f libsophia.a
 	@rm -f libsophia.so
 	@rm -f libsophia.so.1
 	@rm -f libsophia.so.1.2
+
+.PHONY: all banner static dynamic clean


### PR DESCRIPTION
This patch creates a more verbose build process.  Now, to create `sophia.c`, one just types `make sophia.c` :)

Also, somewhat unrelated: I've marked phony targets as such.