### PR TITLE
Fix compile for DragonFly BSD: no fdatasync()

### DIFF
--- a/sophia/std/ss_file.c
+++ b/sophia/std/ss_file.c
@@ -114,9 +114,10 @@ int ss_filesync(ssfile *f)
 {
 #if defined(__APPLE__)
 	return fcntl(f->fd, F_FULLFSYNC);
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 	return fsync(f->fd);
 #else
+    // at least Linux, OpenBSD and NetBSD have fdatasync().
 	return fdatasync(f->fd);
 #endif
 }


### PR DESCRIPTION
DragonFly BSD, like FreeBSD, does not have fdatasync(). Use fsync() instead.
I checked the other BSDs (NetBSD and OpenBSD) seem to have fdatasync()
so it should compile.