### PR TITLE
Implement sp_set_kv() for setting a key/value pair

### DIFF
--- a/sophia/sophia/sophia.h
+++ b/sophia/sophia/sophia.h
@@ -45,6 +45,8 @@ SP_API void    *sp_batch(void*);
 SP_API void    *sp_begin(void*);
 SP_API int      sp_prepare(void*);
 SP_API int      sp_commit(void*);
+SP_API int sp_set_kv(void *ptr, const void *key, int key_sz,
+					 const void *val, int val_sz);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Otherwise we have to lock/unlock the env mutex 5 times instead of just
once. Also I think it is a very common use case which should deserve
it's own function (maybe the name is not appropriate).

It is probably better to implement as an interface function.