### PR TITLE
Implement reverse ordering for u32/u64

### DIFF
--- a/sophia/environment/se_db.c
+++ b/sophia/environment/se_db.c
@@ -82,7 +82,7 @@ se_dbscheme_set(sedb *db)
 	if (s->compression_key) {
 		if (s->fmt == SF_DOCUMENT) {
 			sr_error(&e->error, "%s", "incompatible options: format=document "
-			         "and comppression_key=1");
+			         "and compression_key=1");
 			return -1;
 		}
 		s->fmt_storage = SF_SKEYVALUE;

--- a/sophia/runtime/sr_scheme.c
+++ b/sophia/runtime/sr_scheme.c
@@ -24,19 +24,19 @@ sr_cmpany(char *prefix, int prefixsz,
 	return 0;
 }
 
-#define sr_compare_u32(a, b) \
-do { \
-	uint32_t av = *(uint32_t*)a; \
-	uint32_t bv = *(uint32_t*)b; \
-	if (av == bv) \
-		return 0; \
-	return (av > bv) ? 1 : -1; \
-} while (0)
+static inline sshot int sr_compare_u32(const char *a, const char *b)
+{
+	uint32_t av = *(const uint32_t*)a;
+	uint32_t bv = *(const uint32_t*)b;
+	if (av == bv)
+		return 0;
+	return (av > bv) ? 1 : -1;
+}
 
 static inline sshot int
 sr_cmpu32_raw(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg ssunused)
 {
-	sr_compare_u32(a, b);
+	return sr_compare_u32(a, b);
 }
 
 static inline sshot int
@@ -45,23 +45,23 @@ sr_cmpu32(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg ssunus
 	int part = ((srkey*)arg)->pos;
 	a = sf_key(a, part);
 	b = sf_key(b, part);
-	sr_compare_u32(a, b);
+	return sr_compare_u32(a, b);
 }
 
-#define sr_compare_u64(a, b) \
-do { \
-	uint64_t av = *(uint64_t*)a; \
-	uint64_t bv = *(uint64_t*)b; \
-	if (av == bv) \
-		return 0; \
-	return (av > bv) ? 1 : -1; \
-} while (0)
+static inline sshot int sr_compare_u64(const char *a, const char *b)
+{
+	uint64_t av = *(const uint64_t*)a;
+	uint64_t bv = *(const uint64_t*)b;
+	if (av == bv)
+		return 0;
+	return (av > bv) ? 1 : -1;
+}
 
 static inline sshot int
 sr_cmpu64_raw(char *a, int asz ssunused, char *b, int bsz ssunused,
               void *arg ssunused)
 {
-	sr_compare_u64(a, b);
+	return sr_compare_u64(a, b);
 }
 
 static inline sshot int
@@ -70,7 +70,7 @@ sr_cmpu64(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg)
 	int part = ((srkey*)arg)->pos;
 	a = sf_key(a, part);
 	b = sf_key(b, part);
-	sr_compare_u64(a, b);
+	return sr_compare_u64(a, b);
 }
 
 static inline sshot int

--- a/sophia/runtime/sr_scheme.c
+++ b/sophia/runtime/sr_scheme.c
@@ -48,6 +48,21 @@ sr_cmpu32(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg ssunus
 	return sr_compare_u32(a, b);
 }
 
+static inline sshot int
+sr_cmpu32_raw_reverse(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg ssunused)
+{
+	return -sr_compare_u32(a, b);
+}
+
+static inline sshot int
+sr_cmpu32_reverse(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg ssunused)
+{
+	int part = ((srkey*)arg)->pos;
+	a = sf_key(a, part);
+	b = sf_key(b, part);
+	return -sr_compare_u32(a, b);
+}
+
 static inline sshot int sr_compare_u64(const char *a, const char *b)
 {
 	uint64_t av = *(const uint64_t*)a;
@@ -72,6 +87,23 @@ sr_cmpu64(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg)
 	b = sf_key(b, part);
 	return sr_compare_u64(a, b);
 }
+
+static inline sshot int
+sr_cmpu64_raw_reverse(char *a, int asz ssunused, char *b, int bsz ssunused,
+              void *arg ssunused)
+{
+	return -sr_compare_u64(a, b);
+}
+
+static inline sshot int
+sr_cmpu64_reverse(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg)
+{
+	int part = ((srkey*)arg)->pos;
+	a = sf_key(a, part);
+	b = sf_key(b, part);
+	return -sr_compare_u64(a, b);
+}
+
 
 static inline sshot int
 sr_cmpstring_prefix(char *prefix, int prefixsz, char *key, int keysz,
@@ -165,10 +197,20 @@ int sr_keyset(srkey *part, ssa *a, char *path)
 		cmp = sr_cmpu32;
 		cmpraw = sr_cmpu32_raw;
 	} else
+	if (strcmp(path, "-u32") == 0) {
+		type = SS_U32;
+		cmp = sr_cmpu32_reverse;
+		cmpraw = sr_cmpu32_raw_reverse;
+	} else
 	if (strcmp(path, "u64") == 0) {
 		type = SS_U64;
 		cmp = sr_cmpu64;
 		cmpraw = sr_cmpu64_raw;
+	} else
+	if (strcmp(path, "-u64") == 0) {
+		type = SS_U64;
+		cmp = sr_cmpu64_reverse;
+		cmpraw = sr_cmpu64_raw_reverse;
 	} else {
 		return -1;
 	}


### PR DESCRIPTION
This allows reverse ordering in a simple way. Maybe name "-u32" to "u32_desc"? If accepted, I will come up with some test cases. I have some in rust-sophia already.