### PR TITLE
check for mmap return value instead of p

### DIFF
--- a/sophia/std/ss_pager.c
+++ b/sophia/std/ss_pager.c
@@ -54,7 +54,7 @@ int ss_pageradd(sspager *p)
 	sspagepool *pp =
 		mmap(NULL, p->pool_size, PROT_READ|PROT_WRITE|PROT_EXEC,
 	         MAP_PRIVATE|MAP_ANON, -1, 0);
-	if (ssunlikely(p == MAP_FAILED))
+	if (ssunlikely(pp == MAP_FAILED))
 		return -1;
 	pp->used = 0;
 	pp->next = p->pp;


### PR DESCRIPTION
$ softlimit -a 860000000 ./batch 
Segmentation fault (core dumped)

(gdb) bt
#0  ss_pageradd (p=0x55aa8f8d8590) at sophia/std/ss_pager.c:59
#1  0x000055aa8f733675 in ss_pagerpop (p=0x55aa8f8d8590) at sophia/std/ss_pager.c:71
#2  0x000055aa8f7336fb in ss_sagrow (s=0x55aa8f8d8878) at sophia/std/ss_slaba.c:32
#3  ss_slabamalloc (a=0x55aa8f8d8870, size=<optimized out>) at sophia/std/ss_slaba.c:89
#4  0x000055aa8f741ef2 in ss_malloc (size=65, a=<optimized out>) at sophia/std/ss_a.h:45
#5  sx_valloc (v=0x55aa9ab5cdf0, asxv=<optimized out>) at sophia/transaction/sx_v.h:28
#6  sx_set (t=t@entry=0x7f81028ad05c, index=index@entry=0x7f81028c3c8c, version=0x55aa9ab5cdf0) at sophia/transaction/sx.c:285
#7  0x000055aa8f751841 in se_txwrite (t=0x7f81028ad024, o=<optimized out>, flags=<optimized out>) at sophia/environment/se_tx.c:65
#8  0x000055aa8f753f4e in se_recoverlog (log=0x55aa8f8f46c0, e=<optimized out>) at sophia/environment/se_recover.c:111
#9  se_recoverlogpool (e=0x55aa8f8d8010) at sophia/environment/se_recover.c:150
#10 se_recover (e=e@entry=0x55aa8f8d8010) at sophia/environment/se_recover.c:172
#11 0x000055aa8f75a850 in se_open (o=0x55aa8f8d8010) at sophia/environment/se.c:56
#12 0x000055aa8f75a988 in sp_open (ptr=<optimized out>) at sophia/sophia/sophia.c:75
#13 0x000055aa8f712d19 in main (argc=<optimized out>, argv=<optimized out>) at batch.c:31