### PR TITLE
Undef __BLOCKS__

### DIFF
--- a/sophia/sophia/sophia.h
+++ b/sophia/sophia/sophia.h
@@ -1,6 +1,8 @@
 #ifndef SOPHIA_H_
 #define SOPHIA_H_
 
+#undef __BLOCKS__
+
 /*
  * sophia database
  * sphia.org


### PR DESCRIPTION
Hey,

I'm currently building Rust bindings for Sophia and cannot generate respective bindings due to the proprietary "blocks" addition to Clang by Apple.

This unsets `__BLOCKS__` so that Clang emits correct IR code that `bindgen` (a Rust helper tool that generates bindings) can interprete (it does not support the Apple `BlockPointer` type).
