### PR TITLE
added param string_rev for reverse order of keys with same size

### DIFF
--- a/sophia/format/sf_scheme.c
+++ b/sophia/format/sf_scheme.c
@@ -24,6 +24,19 @@ sf_cmpstring(char *a, int asz, char *b, int bsz, void *arg ssunused)
 }
 
 static inline sshot int
+sf_cmpstring_reverse(char *a, int asz, char *b, int bsz, void *arg ssunused)
+{
+	int size = (asz < bsz) ? asz : bsz;
+	int rc = memcmp(a, b, size);
+	if (ssunlikely(rc == 0)) {
+		if (sslikely(asz == bsz))
+			return 0;
+		return (asz < bsz) ? -1 : 1;
+	}
+	return rc > 0 ? -1 : 1;
+}
+
+static inline sshot int
 sf_cmpu8(char *a, int asz ssunused, char *b, int bsz ssunused, void *arg ssunused)
 {
 	uint8_t av = *(uint8_t*)a;
@@ -196,6 +209,11 @@ sf_schemeset(sfscheme *s, sffield *f, char *opt)
 		f->type = SS_STRING;
 		f->fixed_size = 0;
 		f->cmp = sf_cmpstring;
+	} else
+	if (strcmp(opt, "string_rev") == 0) {
+		f->type = SS_STRING;
+		f->fixed_size = 0;
+		f->cmp = sf_cmpstring_reverse;
 	} else
 	if (strcmp(opt, "u8") == 0) {
 		f->type = SS_U8;


### PR DESCRIPTION
Hi, Dima!
This little PR add reverse order for string keys
For example you have keys:
```
r:99:105
r:100:123
r:101:100
r:102:9
r:1000:1
```
And you need to iterate keys in reverse order:
```
//db settings
sp_setstring(env, "db.db.scheme", "key", 0);
sp_setstring(env, "db.db.scheme.key", "string_rev,key(0)", 0);
//cursor settings
sp_setstring(o, "order", ">=", 0)
sp_setstring(o, "prefix", "r:10", strlen("r:10"));
//return
r:102:9
r:101:100
r:100:123
r:1000:1
```
it's useful for key:timestamp for example, then key is string
I use it here: https://github.com/recoilme/okdb